### PR TITLE
update PhotoSlideshow

### DIFF
--- a/_includes/armystarlogos.html
+++ b/_includes/armystarlogos.html
@@ -1,10 +1,4 @@
-<section id="armystarlogos">
-    <div class="container">
-        <div class="inner-container">
-            <h2>05 | ARMY STAR LOGOS</h2>
-            <td height="109"><img src="/e2/images/rv7/symbols/guts_19.jpg" alt="The United States Army Logo" width="93" height="102"></td>
-			<p><a href="/e2/downloads/rv7/symbols/army_star_light_background.png" target="_blank" onclick="_gaq.push(['_trackEvent', 'downloads', 'png', '/e2/downloads/rv7/symbols/army_star_light_background.png', , true]);">Black Trademark PNG</a></p>
-		 	<p><a href="/e2/downloads/rv7/symbols/army_star_dark_background.png" target="_blank" onclick="_gaq.push(['_trackEvent', 'downloads', 'png', '/e2/downloads/rv7/symbols/army_star_dark_background.png', , true]);">Yellow Trademark PNG</a></p>
-        </div>
-    </div>
-</section>
+<div class="armystarlogos">
+	<p><a href="/e2/downloads/rv7/symbols/army_star_light_background.png" target="_blank" onclick="_gaq.push(['_trackEvent', 'downloads', 'png', '/e2/downloads/rv7/symbols/army_star_light_background.png', , true]);">Black Trademark PNG</a></p>
+ 	<p><a href="/e2/downloads/rv7/symbols/army_star_dark_background.png" target="_blank" onclick="_gaq.push(['_trackEvent', 'downloads', 'png', '/e2/downloads/rv7/symbols/army_star_dark_background.png', , true]);">Yellow Trademark PNG</a></p>
+</div>

--- a/_includes/elements.html
+++ b/_includes/elements.html
@@ -35,6 +35,10 @@
                 {% include elements/social-media.html %}
             </div>
             <div class="elem">
+                <h4>ARMY STAR LOGOS</h4>
+                {% include armystarlogos.html %}
+            </div>
+            <div class="elem">
                 <h4>ACCORDION</h4>
                 {% include elements/accordion.html %}
             </div>

--- a/index.html
+++ b/index.html
@@ -10,4 +10,3 @@ layout: default
 {% include typography.html %}
 {% include section-break.html %}
 {% include elements.html %}
-{% include armystarlogos.html %}


### PR DESCRIPTION
Replace require with import for Helper class.

Adds a class ("has-click") when a click event listener is added to a DOM element. It only adds the event listener if it does not have this class. This prevents adding the same click events multiple times, if the class is instantiated multiple times.