### PR TITLE
update the slideshow image container ratio to a true 3:2

### DIFF
--- a/_scss/elements/_photo-slideshow.scss
+++ b/_scss/elements/_photo-slideshow.scss
@@ -22,7 +22,7 @@
         line-height: 0;
         position: relative;
         text-align: center;
-        padding: 0 0 67.9%; // 640x435 Core2 ratio
+        padding: 0 0 66.667%; // 3:2 ratio
         overflow: hidden;
         background-color: #000;
         


### PR DESCRIPTION
…instead of Core2's 640x435 dimensions